### PR TITLE
feat: display name update

### DIFF
--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Check, LogOut, Monitor, Moon, Sun } from 'lucide-react'
 import { useAuth } from '../hooks/useAuth'
 import { useTheme } from '../hooks/useTheme'
@@ -21,6 +21,13 @@ export default function ProfilePage() {
   const [signingOut, setSigningOut] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [saved, setSaved] = useState(false)
+
+  // Auto-dismiss saved indicator after 3 seconds
+  useEffect(() => {
+    if (!saved) return
+    const timer = setTimeout(() => setSaved(false), 3000)
+    return () => clearTimeout(timer)
+  }, [saved])
 
   // Show local edit value once user types; otherwise show server value
   const shownName = displayName ?? profile?.display_name ?? ''

--- a/src/pages/WorkoutPage.tsx
+++ b/src/pages/WorkoutPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Plus, Dumbbell, Loader2 } from "lucide-react";
 import { useAuth } from "../hooks/useAuth";
+import { useProfile } from "../hooks/useProfile";
 import {
   useTodayWorkout,
   useCreateWorkout,
@@ -12,6 +13,7 @@ import ExercisePicker from "../components/ExercisePicker";
 
 export default function WorkoutPage() {
   const { user } = useAuth();
+  const { profile } = useProfile();
   const userId = user?.id;
 
   const { data: todayWorkouts = [], isLoading: loadingWorkout } =
@@ -42,7 +44,7 @@ export default function WorkoutPage() {
 
   if (loadingWorkout) {
     return (
-      <div className="flex min-h-svh items-center justify-center bg-white dark:bg-gray-950">
+      <div className="flex min-h-svh items-center justify-center bg-white dark:bg-gray-950" role="status" aria-label="Loading workout">
         <Loader2 className="h-8 w-8 animate-spin text-indigo-600 dark:text-indigo-400" />
       </div>
     );
@@ -52,9 +54,14 @@ export default function WorkoutPage() {
   if (!workout) {
     return (
       <div className="flex min-h-svh flex-col items-center justify-center gap-4 bg-white px-4 dark:bg-gray-950">
-        <Dumbbell className="h-16 w-16 text-gray-300 dark:text-gray-700" />
+        <Dumbbell className="h-16 w-16 text-gray-300 dark:text-gray-700" aria-hidden="true" />
+        <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+          Start a Workout
+        </h1>
         <p className="text-center text-gray-500 dark:text-gray-400">
-          No workout started today
+          {profile?.display_name
+            ? `Ready to train, ${profile.display_name}?`
+            : "No workout started today"}
         </p>
         <button
           onClick={handleStartWorkout}
@@ -74,7 +81,7 @@ export default function WorkoutPage() {
           )}
         </button>
         {createWorkout.isError && (
-          <p className="text-sm text-red-600 dark:text-red-400">
+          <p role="alert" className="text-sm text-red-600 dark:text-red-400">
             {createWorkout.error.message}
           </p>
         )}
@@ -87,6 +94,11 @@ export default function WorkoutPage() {
     <div className="min-h-svh bg-white dark:bg-gray-950">
       {/* Header */}
       <div className="border-b border-gray-200 px-4 py-4 dark:border-gray-800">
+        {profile?.display_name && (
+          <p className="text-sm font-medium text-indigo-600 dark:text-indigo-400">
+            Hey, {profile.display_name} 👋
+          </p>
+        )}
         <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">
           Today&rsquo;s Workout
         </h1>


### PR DESCRIPTION
## Summary

Completes the display name update flow (Issue #22). The core edit/save functionality was already implemented in #12/#48. This PR adds polish:

- **Auto-dismiss saved indicator** — the "Saved" checkmark on ProfilePage now fades after 3 seconds instead of persisting until next edit
- **Personalized greeting on WorkoutPage** — shows "Hey, {name} 👋" in the workout header and "Ready to train, {name}?" on the empty-workout screen when a display name is set

### Acceptance Criteria
- [x] Display name field shows current value
- [x] Can edit the display name
- [x] Save updates database
- [x] Success feedback shown (auto-dismissing)
- [x] Display name appears in greeting on workout page

Closes #22