### PR TITLE
feat: edit/delete body weight entry

### DIFF
--- a/src/hooks/useBodyWeight.ts
+++ b/src/hooks/useBodyWeight.ts
@@ -2,7 +2,7 @@ import { supabase } from "../lib/supabase";
 import { useSupabaseQuery } from "./useSupabaseQuery";
 import { useSupabaseMutation } from "./useSupabaseMutation";
 import { queryKeys } from "./queryKeys";
-import type { BodyWeight } from "../types";
+import type { BodyWeight, BodyWeightUpdate } from "../types";
 
 export function useBodyWeights(userId: string | undefined) {
   return useSupabaseQuery<BodyWeight>(
@@ -33,6 +33,37 @@ export function useUpsertBodyWeight() {
         .single();
       if (error) throw error;
       return data as BodyWeight;
+    },
+    invalidateKeys: [queryKeys.bodyWeights.all],
+  });
+}
+
+/** Update an existing body weight entry. */
+export function useUpdateBodyWeight() {
+  return useSupabaseMutation<BodyWeight, BodyWeightUpdate>({
+    mutationFn: async ({ id, ...fields }) => {
+      const { data, error } = await supabase
+        .from("body_weights")
+        .update(fields)
+        .eq("id", id)
+        .select()
+        .single();
+      if (error) throw error;
+      return data as BodyWeight;
+    },
+    invalidateKeys: [queryKeys.bodyWeights.all],
+  });
+}
+
+/** Delete a body weight entry by id. */
+export function useDeleteBodyWeight() {
+  return useSupabaseMutation<void, string>({
+    mutationFn: async (id) => {
+      const { error } = await supabase
+        .from("body_weights")
+        .delete()
+        .eq("id", id);
+      if (error) throw error;
     },
     invalidateKeys: [queryKeys.bodyWeights.all],
   });

--- a/src/pages/WeightPage.tsx
+++ b/src/pages/WeightPage.tsx
@@ -1,7 +1,13 @@
 import { useState, type FormEvent } from "react";
-import { CheckCircle, Scale } from "lucide-react";
+import { CheckCircle, Pencil, Scale, Trash2, X } from "lucide-react";
 import { useAuth } from "../hooks/useAuth";
-import { useBodyWeights, useUpsertBodyWeight } from "../hooks/useBodyWeight";
+import {
+  useBodyWeights,
+  useUpsertBodyWeight,
+  useUpdateBodyWeight,
+  useDeleteBodyWeight,
+} from "../hooks/useBodyWeight";
+import type { BodyWeight } from "../types";
 
 function todayISO(): string {
   const d = new Date();
@@ -19,11 +25,20 @@ function formatDate(iso: string): string {
 export default function WeightPage() {
   const { user } = useAuth();
   const upsert = useUpsertBodyWeight();
+  const updateMutation = useUpdateBodyWeight();
+  const deleteMutation = useDeleteBodyWeight();
   const { data: entries = [], isLoading } = useBodyWeights(user?.id);
 
   const [date, setDate] = useState(todayISO);
   const [weight, setWeight] = useState("");
   const [showSuccess, setShowSuccess] = useState(false);
+
+  // Edit state
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editWeight, setEditWeight] = useState("");
+
+  // Delete confirmation state
+  const [deletingEntry, setDeletingEntry] = useState<BodyWeight | null>(null);
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -41,6 +56,30 @@ export default function WeightPage() {
     setShowSuccess(true);
     setWeight("");
     setTimeout(() => setShowSuccess(false), 3000);
+  }
+
+  function startEdit(entry: BodyWeight) {
+    setEditingId(entry.id);
+    setEditWeight(String(entry.weight));
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+    setEditWeight("");
+  }
+
+  async function saveEdit(entry: BodyWeight) {
+    const parsed = parseFloat(editWeight);
+    if (isNaN(parsed) || parsed <= 0) return;
+    await updateMutation.mutateAsync({ id: entry.id, weight: parsed });
+    setEditingId(null);
+    setEditWeight("");
+  }
+
+  async function confirmDelete() {
+    if (!deletingEntry) return;
+    await deleteMutation.mutateAsync(deletingEntry.id);
+    setDeletingEntry(null);
   }
 
   return (
@@ -131,22 +170,131 @@ export default function WeightPage() {
           ) : (
             <ul className="mt-3 divide-y divide-gray-200 overflow-y-auto dark:divide-gray-800">
               {entries.map((entry) => (
-                <li
-                  key={entry.id}
-                  className="flex items-center justify-between py-3"
-                >
-                  <span className="text-sm text-gray-600 dark:text-gray-400">
-                    {formatDate(entry.date)}
-                  </span>
-                  <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                    {entry.weight} lbs
-                  </span>
+                <li key={entry.id} className="py-3">
+                  {editingId === entry.id ? (
+                    <div className="flex items-center gap-2">
+                      <span className="shrink-0 text-sm text-gray-600 dark:text-gray-400">
+                        {formatDate(entry.date)}
+                      </span>
+                      <input
+                        type="number"
+                        inputMode="decimal"
+                        step="0.1"
+                        min="0"
+                        autoFocus
+                        value={editWeight}
+                        onChange={(e) => setEditWeight(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            e.preventDefault();
+                            saveEdit(entry);
+                          } else if (e.key === "Escape") {
+                            cancelEdit();
+                          }
+                        }}
+                        className="min-h-[36px] w-24 rounded-md border border-indigo-400 bg-white px-2 py-1 text-sm text-gray-900 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-indigo-500 dark:bg-gray-900 dark:text-gray-100"
+                      />
+                      <span className="text-sm text-gray-500 dark:text-gray-400">
+                        lbs
+                      </span>
+                      <div className="ml-auto flex gap-1">
+                        <button
+                          type="button"
+                          onClick={() => saveEdit(entry)}
+                          disabled={updateMutation.isPending}
+                          className="min-h-[36px] min-w-[36px] rounded-md bg-indigo-600 px-2 py-1 text-xs font-medium text-white transition-colors hover:bg-indigo-700 disabled:opacity-50 dark:bg-indigo-500 dark:hover:bg-indigo-600"
+                        >
+                          {updateMutation.isPending ? "…" : "Save"}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={cancelEdit}
+                          className="min-h-[36px] min-w-[36px] rounded-md p-1 text-gray-400 transition-colors hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+                          aria-label="Cancel edit"
+                        >
+                          <X className="h-4 w-4" />
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-gray-600 dark:text-gray-400">
+                        {formatDate(entry.date)}
+                      </span>
+                      <div className="flex items-center gap-3">
+                        <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                          {entry.weight} lbs
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => startEdit(entry)}
+                          className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md p-2 text-gray-400 transition-colors hover:text-indigo-600 dark:text-gray-500 dark:hover:text-indigo-400"
+                          aria-label={`Edit weight for ${formatDate(entry.date)}`}
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setDeletingEntry(entry)}
+                          className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md p-2 text-gray-400 transition-colors hover:text-red-600 dark:text-gray-500 dark:hover:text-red-400"
+                          aria-label={`Delete weight for ${formatDate(entry.date)}`}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </div>
+                    </div>
+                  )}
                 </li>
               ))}
             </ul>
           )}
         </section>
       </div>
+
+      {/* Delete confirmation modal */}
+      {deletingEntry && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
+          onClick={() => setDeletingEntry(null)}
+        >
+          <div
+            className="w-full max-w-xs rounded-xl bg-white p-6 shadow-xl dark:bg-gray-900"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              Delete Entry
+            </h3>
+            <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+              Delete the {deletingEntry.weight} lbs entry from{" "}
+              {formatDate(deletingEntry.date)}? This cannot be undone.
+            </p>
+
+            {deleteMutation.isError && (
+              <div className="mt-3 rounded-lg bg-red-50 p-2 text-sm text-red-700 dark:bg-red-900/30 dark:text-red-400">
+                {deleteMutation.error?.message ?? "Failed to delete"}
+              </div>
+            )}
+
+            <div className="mt-5 flex gap-3">
+              <button
+                type="button"
+                onClick={() => setDeletingEntry(null)}
+                className="min-h-[44px] flex-1 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={confirmDelete}
+                disabled={deleteMutation.isPending}
+                className="min-h-[44px] flex-1 rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-700 disabled:opacity-50 dark:bg-red-500 dark:hover:bg-red-600"
+              >
+                {deleteMutation.isPending ? "Deleting…" : "Delete"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds edit and delete functionality to body weight entries on the Weight page.

### Changes

**`src/hooks/useBodyWeight.ts`**
- Added `useUpdateBodyWeight` hook — updates weight value via Supabase `.update()` with cache invalidation
- Added `useDeleteBodyWeight` hook — deletes entry by id via Supabase `.delete()` with cache invalidation

**`src/pages/WeightPage.tsx`**
- Each history entry now shows pencil (edit) and trash (delete) action buttons with 44px touch targets
- **Edit**: Inline editing — tapping pencil reveals a number input with Save/Cancel; supports Enter to save, Escape to cancel
- **Delete**: Tapping trash opens a confirmation modal with Cancel/Delete buttons; shows error state on failure

### Acceptance Criteria
- [x] Tapping entry opens edit mode
- [x] Can update weight value
- [x] Can delete entry
- [x] Delete requires confirmation
- [x] List updates after changes

Closes #27