### PR TITLE
feat: chart time range filter

### DIFF
--- a/src/lib/timeRange.ts
+++ b/src/lib/timeRange.ts
@@ -39,6 +39,7 @@ export function filterByDateRange<T extends { date: string }>(
   range: TimeRange,
 ): T[] {
   const start = getStartDate(range);
+  if (!start) return data;
   const startISO = start.toISOString().slice(0, 10);
   return data.filter((d) => d.date >= startISO);
 }

--- a/src/pages/ChartsPage.tsx
+++ b/src/pages/ChartsPage.tsx
@@ -1,86 +1,142 @@
-import { useState } from "react";
-import { TrendingUp } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Scale, TrendingUp } from "lucide-react";
 import { useAuth } from "../hooks/useAuth";
 import {
   useLoggedExercises,
   useExerciseProgress,
 } from "../hooks/useExerciseProgress";
+import { useBodyWeights } from "../hooks/useBodyWeight";
 import ExerciseProgressChart from "../components/ExerciseProgressChart";
+import BodyWeightChart from "../components/BodyWeightChart";
+import TimeRangeFilter from "../components/TimeRangeFilter";
+import {
+  DEFAULT_TIME_RANGE,
+  filterByDateRange,
+  type TimeRange,
+} from "../lib/timeRange";
 
 export default function ChartsPage() {
   const { user } = useAuth();
   const [selectedExerciseId, setSelectedExerciseId] = useState<string>("");
+  const [timeRange, setTimeRange] = useState<TimeRange>(DEFAULT_TIME_RANGE);
 
-  const {
-    data: exercises,
-    isLoading: exercisesLoading,
-  } = useLoggedExercises(user?.id);
+  const { data: exercises, isLoading: exercisesLoading } = useLoggedExercises(
+    user?.id,
+  );
 
-  const {
-    data: progressData,
-    isLoading: progressLoading,
-  } = useExerciseProgress(selectedExerciseId || undefined);
+  const { data: progressData, isLoading: progressLoading } =
+    useExerciseProgress(selectedExerciseId || undefined);
+
+  const { data: bodyWeightData, isLoading: bodyWeightLoading } =
+    useBodyWeights(user?.id);
+
+  const filteredProgressData = useMemo(
+    () => (progressData ? filterByDateRange(progressData, timeRange) : []),
+    [progressData, timeRange],
+  );
+
+  const filteredBodyWeightData = useMemo(() => {
+    if (!bodyWeightData) return [];
+    const sorted = [...bodyWeightData].sort((a, b) =>
+      a.date.localeCompare(b.date),
+    );
+    return filterByDateRange(sorted, timeRange);
+  }, [bodyWeightData, timeRange]);
 
   return (
     <div className="min-h-svh bg-white px-4 pt-6 pb-4 dark:bg-gray-950">
-      <h1 className="mb-6 text-2xl font-bold text-gray-900 dark:text-gray-100">
-        Charts
-      </h1>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+          Charts
+        </h1>
+        <TimeRangeFilter value={timeRange} onChange={setTimeRange} />
+      </div>
 
-      {/* Exercise selector */}
-      <label
-        htmlFor="exercise-select"
-        className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
-      >
-        Exercise
-      </label>
-      <select
-        id="exercise-select"
-        value={selectedExerciseId}
-        onChange={(e) => setSelectedExerciseId(e.target.value)}
-        disabled={exercisesLoading}
-        className="mb-6 min-h-[44px] w-full rounded-lg border border-gray-300 bg-white px-3 py-2.5 text-base text-gray-900 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-indigo-400 dark:focus:ring-indigo-400"
-      >
-        <option value="">
-          {exercisesLoading ? "Loading…" : "Select an exercise"}
-        </option>
-        {exercises?.map((ex) => (
-          <option key={ex.id} value={ex.id}>
-            {ex.name}
+      {/* Exercise Progression */}
+      <section className="mb-8">
+        <h2 className="mb-3 text-lg font-semibold text-gray-900 dark:text-gray-100">
+          Exercise Progression
+        </h2>
+
+        <label
+          htmlFor="exercise-select"
+          className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Exercise
+        </label>
+        <select
+          id="exercise-select"
+          value={selectedExerciseId}
+          onChange={(e) => setSelectedExerciseId(e.target.value)}
+          disabled={exercisesLoading}
+          className="mb-4 min-h-[44px] w-full rounded-lg border border-gray-300 bg-white px-3 py-2.5 text-base text-gray-900 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-indigo-400 dark:focus:ring-indigo-400"
+        >
+          <option value="">
+            {exercisesLoading ? "Loading…" : "Select an exercise"}
           </option>
-        ))}
-      </select>
+          {exercises?.map((ex) => (
+            <option key={ex.id} value={ex.id}>
+              {ex.name}
+            </option>
+          ))}
+        </select>
 
-      {/* Chart area */}
-      {!selectedExerciseId && (
-        <div className="flex flex-col items-center justify-center py-20 text-gray-400 dark:text-gray-500">
-          <TrendingUp className="mb-3 h-12 w-12" />
-          <p className="text-sm">Select an exercise to view progression</p>
-        </div>
-      )}
-
-      {selectedExerciseId && progressLoading && (
-        <div className="flex items-center justify-center py-20">
-          <div className="h-8 w-8 animate-spin rounded-full border-4 border-indigo-600 border-t-transparent" />
-        </div>
-      )}
-
-      {selectedExerciseId &&
-        !progressLoading &&
-        progressData &&
-        progressData.length === 0 && (
-          <div className="flex flex-col items-center justify-center py-20 text-gray-400 dark:text-gray-500">
+        {!selectedExerciseId && (
+          <div className="flex flex-col items-center justify-center py-12 text-gray-400 dark:text-gray-500">
             <TrendingUp className="mb-3 h-12 w-12" />
-            <p className="text-sm">No data recorded for this exercise yet</p>
+            <p className="text-sm">Select an exercise to view progression</p>
           </div>
         )}
 
-      {selectedExerciseId &&
-        !progressLoading &&
-        progressData &&
-        progressData.length > 0 && (
-          <ExerciseProgressChart data={progressData} />
+        {selectedExerciseId && progressLoading && (
+          <div className="flex items-center justify-center py-12">
+            <div className="h-8 w-8 animate-spin rounded-full border-4 border-indigo-600 border-t-transparent" />
+          </div>
         )}
+
+        {selectedExerciseId &&
+          !progressLoading &&
+          filteredProgressData.length === 0 && (
+            <div className="flex flex-col items-center justify-center py-12 text-gray-400 dark:text-gray-500">
+              <TrendingUp className="mb-3 h-12 w-12" />
+              <p className="text-sm">
+                No data for this exercise in the selected range
+              </p>
+            </div>
+          )}
+
+        {selectedExerciseId &&
+          !progressLoading &&
+          filteredProgressData.length > 0 && (
+            <ExerciseProgressChart data={filteredProgressData} />
+          )}
+      </section>
+
+      {/* Body Weight */}
+      <section>
+        <h2 className="mb-3 text-lg font-semibold text-gray-900 dark:text-gray-100">
+          Body Weight
+        </h2>
+
+        {bodyWeightLoading && (
+          <div className="flex items-center justify-center py-12">
+            <div className="h-8 w-8 animate-spin rounded-full border-4 border-indigo-600 border-t-transparent" />
+          </div>
+        )}
+
+        {!bodyWeightLoading && filteredBodyWeightData.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-12 text-gray-400 dark:text-gray-500">
+            <Scale className="mb-3 h-12 w-12" />
+            <p className="text-sm">
+              No body weight data in the selected range
+            </p>
+          </div>
+        )}
+
+        {!bodyWeightLoading && filteredBodyWeightData.length > 0 && (
+          <BodyWeightChart data={filteredBodyWeightData} />
+        )}
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Add time range filtering to the Charts page with 6 options (1W, 1M, 3M, 6M, 1Y, All), defaulting to 3M.

## Changes

- **`src/pages/ChartsPage.tsx`**: Integrated time range filter, added body weight chart section, both charts filtered by selected range using `useMemo`
- **`src/lib/timeRange.ts`**: Fixed null-check bug in `filterByDateRange` for the "ALL" range
- Leverages existing `TimeRangeFilter`, `BodyWeightChart` components and `useBodyWeights` hook

## Acceptance Criteria
- [x] Time range selector visible (button group in page header)
- [x] 6 options available (1W, 1M, 3M, 6M, 1Y, All)
- [x] Filter applies to exercise progression chart
- [x] Filter applies to body weight chart
- [x] Default selection is 3M

Closes #28